### PR TITLE
CompatHelper: bump compat for JLD2 to 0.6, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ gmsh_jll = "630162c2-fc9b-58b3-9910-8442a8a132e6"
 
 [compat]
 Arpack = "v0.5"
-JLD2 = "0.5.15"
+JLD2 = "0.5.15, 0.6"
 LinearAlgebra = "1.11.0"
 Polyester = "0.7.18"
 SparseArrays = "1.11.0"


### PR DESCRIPTION
This pull request changes the compat entry for the `JLD2` package from `0.5.15` to `0.5.15, 0.6`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.